### PR TITLE
Add Shortcut links to Clubhouse doc

### DIFF
--- a/zerver/webhooks/clubhouse/doc.md
+++ b/zerver/webhooks/clubhouse/doc.md
@@ -1,8 +1,8 @@
 # Zulip Clubhouse integration
 
-Get Zulip notifications for your Clubhouse(now known as Shortcut) Stories and Epics!
+Get Zulip notifications for your Clubhouse(now known as [Shortcut](https://www.shortcut.com/)) Stories and Epics!
 
-> **Note**: Clubhouse has changed its name to Shortcut. However, for backward compatibility and to avoid confusion, we will continue to us the name "Clubhouse" in this documentation.
+> **Note**: Clubhouse has changed its name to **[Shortcut](https://www.shortcut.com/)**. However, for backward compatibility and to avoid confusion, we will continue to us the name "**Clubhouse**" in this documentation.
 
 {start_tabs}
 


### PR DESCRIPTION
This PR adds links to Shortcut - the new name of Clubhouse to the Clubhouse docs.